### PR TITLE
3015 enable dependabot for rust

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       interval: "daily"
       time: "03:00"
     open-pull-requests-limit: 10
-  - package-ecosystem: "rust"
+  - package-ecosystem: "cargo"
     directory: "/rust"
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
       interval: "daily"
       time: "03:00"
     open-pull-requests-limit: 10
+  - package-ecosystem: "rust"
+    directory: "/rust"
+    schedule:
+      interval: daily
+      time: "03:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
### Description

In this pull request, the configuration in the `.github/dependabot.yml` file is being updated to include dependabot monitoring for a new package ecosystem, `cargo`, within the `/rust` directory. The existing setup for updating dependencies in this ecosystem will run daily at 03:00 with a limit of 10 open pull requests.

- Add dependabot monitoring for the `cargo` package ecosystem within the `/rust` directory.
- Configure dependabot to run daily at 03:00 for the `cargo` ecosystem in the `/rust` directory.
- Set the limit of open pull requests to 10 for the `cargo` ecosystem within the `/rust` directory.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enable Dependabot for Rust by adding configuration for the Cargo package ecosystem in the dependabot.yml file.

### Why are these changes being made?

To automate dependency updates for Rust projects, ensuring they remain up-to-date and secure. This change aligns with existing configurations for other ecosystems and maintains consistency in dependency management practices.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->